### PR TITLE
Ability to get data about all projects

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,6 +91,8 @@ app.put('/repository/:name/:version', repository.package.put);
 app.delete('/repository/:name/:version', repository.package.checkPermission, repository.package.delete);
 app.get('/repository/:name/:version/:filename', repository.filename.get);
 
+app.get('/repositories', repository.data);
+
 app.get('/docs/:name/:version/*', docs);
 
 // 404

--- a/models/project.js
+++ b/models/project.js
@@ -128,4 +128,30 @@ Project.getAll = function() {
   return fs.readdirSync(path.join(CONFIG.wwwroot, 'repository'));
 };
 
+Project.getData = function(filter) {
+  var projectNames = filter.projects;
+  var fieldNames = filter.fields;
+  var allProjectNames = Project.getAll();
+  var results = [];
+  for (var i = 0, q = allProjectNames.length; i < q; i++) {
+    var name = allProjectNames[i];
+    if (!projectNames || projectNames.indexOf(name) > -1) {
+      var prj = new Project({
+        name: name
+      });
+      var project = fieldNames ? {} : prj;
+      if (fieldNames) {
+        for (var k = 0, n = fieldNames.length; k < n; k++) {
+          var field = fieldNames[k];
+          if (field in prj) {
+            project[field] = prj[field];
+          }
+        }
+      }
+      results.push(project);
+    }
+  }
+  return results;
+};
+
 module.exports = Project;

--- a/routes/repository.js
+++ b/routes/repository.js
@@ -288,6 +288,20 @@ exports.search = function(req, res, next) {
   });
 };
 
+exports.data = function(req, res) {
+  var query = req.query;
+  var data = Project.getData({
+    projects: query.projects ? query.projects.split(",") : null,
+    fields: query.fields ? query.fields.split(",") : null
+  });
+  res.send(200, {
+    data: {
+      total: data.length,
+      results: data
+    }
+  });
+};
+
 function abortify(res, options) {
   code = options.code || 401;
   status = options.status || 'error';


### PR DESCRIPTION
Hello,

I have added ability to get data about all available projects.
Data are accessible by the following URL:
http://spmjs.io/repositories/
It is possible to apply filter for project names and specify which fields should be included into project’s data. For example:
http://spmjs.io/repositories/?projects=imagic,mixing,kemo,madge&fields=name,description,keywords,license,version
Moreover if you approve adding [minimatch](https://github.com/isaacs/minimatch) or [gex](https://github.com/rjrodger/gex) as dependency I will improve filtering so that it will possible to specify projects or fields by pattern.
