### PR TITLE
Fix GitHub login account changed problem

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -20,7 +20,7 @@ var cacheIndex = require('./cacheIndex');
 
 hook.on('create:project', function(project, publisher) {
   console.log('create', project.name);
-  if (publisherId) {
+  if (publisher && publisher.id) {
     account.save(publisher.id, {
       $inc: {
         count: 1

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -20,8 +20,8 @@ var cacheIndex = require('./cacheIndex');
 
 hook.on('create:project', function(project, publisher) {
   console.log('create', project.name);
-  if (publisher) {
-    account.save(publisher, {
+  if (publisherId) {
+    account.save(publisher.id, {
       $inc: {
         count: 1
       }
@@ -35,7 +35,7 @@ hook.on('update:package', function(package) {
   history.add({
     name: package.name,
     version: package.version,
-    publisher: package.publisher || '',
+    publisher: package.publisher || {},
     time: Date.now(),
     action: 'publish'
   });
@@ -64,8 +64,8 @@ hook.on('delete:project', function(project, unpublisher) {
   // remove index
   client.delete('spmjs', 'package', project.name);
   // substract count
-  if (unpublisher) {
-    account.save(unpublisher, {
+  if (unpublisher && unpublisher.id) {
+    account.save(unpublisher.id, {
       $inc: {
         count: -1
       }
@@ -87,7 +87,7 @@ hook.on('delete:package', function(package) {
   history.add({
     name: package.name,
     version: package.version,
-    unpublisher: package.publisher || '',
+    unpublisher: package.publisher || {},
     time: Date.now(),
     action: 'unpublish'
   });

--- a/routes/account.js
+++ b/routes/account.js
@@ -25,19 +25,19 @@ exports.index = function(req, res) {
       anonymous: anonymous,
       GA: CONFIG.website.GA,
       profile: profile,
-      ownPackages: account.getPackages(profile.login),
+      ownPackages: account.getPackages(profile.id),
       errormessage: req.query.errormessage
     });
   }
 };
 
 exports.user = function(req, res, next) {
-  account.get(req.params.user, function(user) {
+  account.getByName(req.params.user, function(user) {
     if (user) {
       var profile = user;
       // not show authkey in public profile
       profile.authkey = null;
-      var packages = account.getPackages(profile.login);
+      var packages = account.getPackages(profile.id);
       res.render('account', {
         title: user.login + ' - ' + CONFIG.website.title,
         spmjsioVersion: spmjsioVersion,
@@ -76,7 +76,7 @@ exports.callback = function(req, res) {
           user.authkey = crypto.createHash('md5').update(token.access_token).digest('hex');
           req.session.user = user;
           // save user to database
-          account.save(user.login, {
+          account.save(user.id, {
             $set: user
           }, function() {
             res.redirect('/account');

--- a/routes/index.js
+++ b/routes/index.js
@@ -108,8 +108,11 @@ exports.project = function(req, res, next) {
     }
 
     var editable;
-    if (p.owners && p.owners.length > 0 && req.session.user &&
-        !anonymous && p.owners.indexOf(req.session.user.login) >= 0) {
+    var ownerIds = p.owners.map(function(owner) {
+      return owner && owner.id;
+    });
+    if (ownerIds && ownerIds.length > 0 && req.session.user &&
+        !anonymous && ownerIds.indexOf(req.session.user.id) >= 0) {
       editable = true;
     }
     if (p.repository && p.repository.url) {

--- a/routes/repository.js
+++ b/routes/repository.js
@@ -118,16 +118,19 @@ exports.package = {
     if (anonymous) {
       next();
     } else {
-      account.getAccountByAuthkey(authkey, function(publisher) {
-        if (!publisher) {
+      account.getAccountByAuthkey(authkey, function(user) {
+        if (!user) {
           return abortify(res, { code: 401 });
         }
 
-        var permission = (!p.created_at) || account.checkPermission(publisher, name);
+        var permission = (!p.created_at) || account.checkPermission(user.id, name);
         if (!permission) {
           return abortify(res, { code: 403 });
         }
-        req.body.publisher = publisher;
+        req.body.publisher = {
+          name: user.login,
+          id: user.id
+        };
         next();
       });
     }

--- a/scripts/fixGithubLoginToId.js
+++ b/scripts/fixGithubLoginToId.js
@@ -1,0 +1,74 @@
+// 把所有包的 owners 和 publisher 字段
+// 替换为 { name: 'xx', id: 12 } 这样的对象
+// 修复 https://github.com/spmjs/spmjs.io/issues/101
+// ---
+var async = require('async');
+
+// load global config
+var yaml = require('node-yaml-config');
+var CONFIG = yaml.load('./config/base.yaml');
+global.CONFIG = CONFIG;
+
+var account = require('../models/account');
+var Project = require('../models/project');
+var Package = require('../models/package');
+
+Project.getAll().forEach(function(projectName) {
+  console.log('Start fixing ' + projectName);
+  var project = new Project({
+    name: projectName
+  });
+
+  var tasks = [];
+  project.owners.forEach(function(ownerName, i) {
+    if (ownerName && typeof ownerName === 'string') {
+      tasks.push(function(callback) {
+        getObjByName(ownerName, function(obj) {
+          console.log('  project owner field fix to ' + obj);
+          project.owners[i] = obj;
+          callback(null, obj);
+        });
+      });
+    }
+  });
+  project.getVersions().forEach(function(version) {
+    var publisher = project.packages[version].publisher;
+    if (publisher && typeof publisher === 'string') {
+      tasks.push(function(callback) {
+        getObjByName(publisher, function(obj) {
+          console.log('  project publisher field fix to ' + obj);
+          project.packages[version].publisher = obj;
+          callback(null, obj);
+        });
+      });
+    }
+  });
+  async.parallel(tasks, function(err, results) {
+    project.save();
+  });
+
+  project.getVersions().forEach(function(version) {
+    var package = new Package({
+      name: projectName,
+      version: version
+    });
+    if (package.publisher && typeof package.publisher === 'string') {
+      getObjByName(package.publisher, function(obj) {
+        console.log('  package publisher field fix to ' + obj);
+        package.publisher = obj;
+        package.save();
+      });
+    }
+  });
+});
+
+function getObjByName(name, callback) {
+  account.getByName(name, function(user) {
+    if (user) {
+      callback({
+        name: user.login,
+        id: user.id
+      });
+    }
+  });
+}

--- a/scripts/reindexPackages.js
+++ b/scripts/reindexPackages.js
@@ -11,11 +11,11 @@ client.deleteIndex('spmjs', function() {
 
   client.createIndex('spmjs', {
     "mappings" : {
-        "package" : {
-            "properties" : {
-                "suggest" : { "type" : "string", "index" : "not_analyzed" }
-            }
+      "package" : {
+        "properties" : {
+          "suggest" : { "type" : "string", "index" : "not_analyzed" }
         }
+      }
     }
   }, function() {
     var operations = [];

--- a/views/package.ejs
+++ b/views/package.ejs
@@ -58,9 +58,9 @@
       <th>Publisher</th>
       <td>
         <% if (anonymous) { %>
-          <%= package.publisher %>
+          <%= package.publisher.name %>
         <% } else { %>
-          <a href="/account/<%= package.publisher %>"><%= package.publisher %></a>
+          <a href="/account/<%= package.publisher.name %>"><%= package.publisher.name %></a>
         <% } %>
       </td>
     </tr>

--- a/views/project.ejs
+++ b/views/project.ejs
@@ -112,12 +112,12 @@
       <td>
       <% project.owners.forEach(function(owner, i) { %>
         <% if (anonymous) { %>
-          <%= owner %><% if(i!==project.owners.length-1){ %>,<% } %>
+          <%= owner.name %><% if(i!==project.owners.length-1){ %>,<% } %>
         <% } else { %>
           <span class="package">
-            <a href="/account/<%= owner %>"><%= owner %></a>
+            <a href="/account/<%= owner.name %>"><%= owner.name %></a>
             <% if (editable) { %>
-              <i title="click to remove ownership" data-target="<%= owner %>" class="iconfont">&#xf000d;</i>
+              <i title="click to remove ownership" data-target="<%= owner.name %>" class="iconfont">&#xf000d;</i>
             <% } %>
           </span>
         <% } %>


### PR DESCRIPTION
修复 #101 。

修复方式是用 github 帐户的 ID(`user.id`) 来代替账户名(`user.login`)作为用户的唯一标示。

升级前需要运行下面的脚本：

```bash
node scripts/fixGithubLoginToId.js
```

用于把 `data/repository` 里 index.json 文件的 owners 和 publisher 字段从 `"账户名"` 替换为一个对象。

```json
{
  "name": "账户名",
  "id": "github帐户id"
}
```